### PR TITLE
Enforce RBAC user lookup and revoke on role change

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,10 @@ The system implements role-based access control:
 - **Responsable**: Technician and equipment management
 - **Admin**: Full system access
 
+#### Immediate RBAC Enforcement
+
+- Every authenticated request resolves the user from the database before granting access. If an operator deactivates an account or downgrades its role, any previously issued token for that user immediately yields **HTTP 403** and the client must re-authenticate. Plan administrative procedures accordingly (forced logout/refresh when adjusting roles).
+
 ### Security Best Practices
 
 - ✅ **Hashed passwords** with bcrypt + strong policy (≥10 chars, mixed case, numbers, symbols)

--- a/app/tests/unit/test_core_and_auth_small.py
+++ b/app/tests/unit/test_core_and_auth_small.py
@@ -76,10 +76,10 @@ def test_get_current_user_fallback(monkeypatch):
     monkeypatch.setattr(
         "app.core.rbac.decode_token", lambda token: {"sub": "42", "role": "responsable"}
     )
-    # Use a DummyDB that returns no user so get_current_user falls back
-    user = get_current_user(token="t", db=DummyDB())
-    assert user["role"] == "responsable"
-    assert user["user_id"] == 42
+    # Use a DummyDB that returns no user -> should now raise 403 instead of returning fallback
+    with pytest.raises(HTTPException) as exc:
+        get_current_user(token="t", db=DummyDB())
+    assert exc.value.status_code == 403
 
 
 # auth_service error paths

--- a/tests/api/test_rbac_revoke.py
+++ b/tests/api/test_rbac_revoke.py
@@ -1,0 +1,33 @@
+from uuid import uuid4
+
+from app.core.security import create_access_token
+from app.schemas.user import UserCreate, UserRole
+from app.services.user_service import create_user
+
+
+def test_role_change_revokes_admin_access(client, db_session):
+    unique = uuid4().hex[:8]
+    email = f"rbac-admin-{unique}@example.com"
+    user_data = UserCreate(
+        username=f"rbac_admin_{unique}",
+        full_name="RBAC Admin",
+        email=email,
+        role=UserRole.admin,
+        password="ChangeMe123!",
+    )
+    admin = create_user(db_session, user_data)
+
+    token = create_access_token(
+        {"sub": admin.email, "role": admin.role.value, "user_id": admin.id}
+    )
+    headers = {"Authorization": f"Bearer {token}"}
+
+    first = client.get(f"/users/{admin.id}", headers=headers)
+    assert first.status_code == 200
+
+    admin.role = UserRole.client
+    db_session.commit()
+    db_session.refresh(admin)
+
+    forbidden = client.get(f"/users/{admin.id}", headers=headers)
+    assert forbidden.status_code == 403

--- a/tests/api/test_users_more.py
+++ b/tests/api/test_users_more.py
@@ -8,10 +8,10 @@ def test_get_my_profile_missing_user(client):
 
 
 def test_update_my_profile_not_found(client):
-    # create a JWT for a non-existent user and attempt update -> should return 404
+    # create a JWT for a non-existent user and attempt update -> should return 403
     from app.core.security import create_access_token
 
     fake_token = create_access_token({"sub": "ghost@example.com", "role": "client", "user_id": 9999})
     payload = {"full_name": "No One"}
     r = client.put("/users/update", json=payload, headers={"Authorization": f"Bearer {fake_token}"})
-    assert r.status_code == 404
+    assert r.status_code == 403

--- a/tests/unit/test_rbac_core.py
+++ b/tests/unit/test_rbac_core.py
@@ -1,3 +1,6 @@
+import pytest
+from fastapi import HTTPException
+
 from app.core.security import create_access_token
 
 
@@ -10,10 +13,9 @@ def test_decode_token_and_get_current_user_fallback(db_session):
 
     # call get_current_user dependency function directly by providing token and db
     # get_current_user is a callable; call it directly with token and db
-    user = get_current_user(token=token, db=db_session)
-    # Should return a dict with role
-    assert isinstance(user, dict)
-    assert user.get("role") == "technicien"
+    with pytest.raises(HTTPException) as exc:
+        get_current_user(token=token, db=db_session)
+    assert exc.value.status_code == 403
 
 
 def test_require_roles_allows_and_denies():


### PR DESCRIPTION
## Summary
- require `get_current_user` to resolve real database users, raising HTTP 403 when the account is missing or inactive and always using the stored role
- align existing tests with the stricter lookup behaviour and add an integration test proving that downgrading a user immediately revokes admin-only access
- document the immediate RBAC enforcement so operators expect forced logouts after role changes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdb518d830833187da265f561df31e